### PR TITLE
Add execution token cache

### DIFF
--- a/agent-config.yml
+++ b/agent-config.yml
@@ -2,7 +2,6 @@ cirro:
   agent:
     url: https://dev.cirro.bio
     id: default-agent
-    log-level: DEBUG
+    log-level: INFO
     work-directory: work/
-    watch-interval: 10
     shared-directory: shared/

--- a/src/main/java/bio/cirro/agent/execution/ExecutionController.java
+++ b/src/main/java/bio/cirro/agent/execution/ExecutionController.java
@@ -20,6 +20,7 @@ import java.util.List;
 public class ExecutionController {
     private final AgentTokenService agentTokenService;
     private final ExecutionService executionService;
+    private final ExecutionTokenService executionTokenService;
 
     @Get
     public HttpResponse<List<ExecutionDto>> list() {
@@ -30,7 +31,7 @@ public class ExecutionController {
     public HttpResponse<AwsCredentials> generateS3Credentials(@PathVariable String executionId,
                                                               @Header("Authorization") String authorization) {
         agentTokenService.validate(authorization, executionId);
-        return HttpResponse.ok(executionService.generateS3Credentials(executionId));
+        return HttpResponse.ok(executionTokenService.generateS3Credentials(executionId));
     }
 
     @Put("/{executionId}/status")

--- a/src/main/java/bio/cirro/agent/execution/ExecutionTokenService.java
+++ b/src/main/java/bio/cirro/agent/execution/ExecutionTokenService.java
@@ -1,0 +1,57 @@
+package bio.cirro.agent.execution;
+
+import bio.cirro.agent.AgentConfig;
+import bio.cirro.agent.aws.AwsCredentials;
+import bio.cirro.agent.aws.AwsTokenClient;
+import bio.cirro.agent.models.Status;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.sts.StsClient;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Singleton
+@Slf4j
+public class ExecutionTokenService {
+    private final ExecutionRepository executionRepository;
+    private final StsClient stsClient;
+    private final AgentConfig agentConfig;
+    private final Map<String, AwsCredentials> executionCredentialsCache;
+
+    public ExecutionTokenService(ExecutionRepository executionRepository, StsClient stsClient, AgentConfig agentConfig) {
+        this.executionRepository = executionRepository;
+        this.stsClient = stsClient;
+        this.agentConfig = agentConfig;
+        this.executionCredentialsCache = new ConcurrentHashMap<>();
+    }
+
+    public AwsCredentials generateS3Credentials(String executionId) {
+        var execution = executionRepository.get(executionId);
+        if (execution.getStatus() == Status.COMPLETED) {
+            throw new IllegalStateException("Execution already completed");
+        }
+
+        if (executionCredentialsCache.containsKey(executionId)) {
+            var cachedCreds = executionCredentialsCache.get(executionId);
+            if (cachedCreds.getExpiration() != null &&
+                    cachedCreds.getExpiration().isAfter(Instant.now())) {
+                log.debug("Using cached S3 credentials for execution: {}", executionId);
+                return cachedCreds;
+            }
+        }
+
+        log.debug("Generating S3 credentials for execution: {}", executionId);
+        var tokenClient = new AwsTokenClient(stsClient, execution.getFileAccessRoleArn(), agentConfig.getId());
+        var creds = tokenClient.generateCredentialsForExecution(execution);
+        var credsResponse = AwsCredentials.builder()
+                .accessKeyId(creds.accessKeyId())
+                .secretAccessKey(creds.secretAccessKey())
+                .sessionToken(creds.sessionToken())
+                .expiration(creds.expirationTime().orElse(null))
+                .build();
+        executionCredentialsCache.put(executionId, credsResponse);
+        return credsResponse;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ cirro:
     url: https://app.cirro.bio
     id: default-agent
     heartbeat-interval: 60
-    watch-interval: 2
+    watch-interval: 10
     log-level: INFO
     work-directory: work/
     version: '@BUILD_VERSION@'


### PR DESCRIPTION
The behavior when using AWS credentials process was not expected.

https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-sourcing-external.html
"The AWS CLI does not cache external process credentials the way it does assume-role credentials. If caching is required, you must implement it in the external process."


Implement token caching inside the agent so we do not make multiple calls to the AWS security token service.