### PR TITLE
Only throw exception on first agent connection attempt

### DIFF
--- a/src/main/java/bio/cirro/agent/AgentCommand.java
+++ b/src/main/java/bio/cirro/agent/AgentCommand.java
@@ -12,7 +12,6 @@ import io.micronaut.configuration.picocli.MicronautFactory;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.env.Environment;
 import io.micronaut.http.HttpRequest;
-import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
@@ -172,13 +171,12 @@ public class AgentCommand implements Runnable {
         catch (WebSocketClientException e) {
             var msg = e.getMessage();
             if (clientSocket == null) {
-                throw new AgentException("Failed to connect, check agent ID: " + msg);
+                throw new AgentException("Failed to connect: " + msg);
             }
             log.error(e.getMessage());
         }
         catch (HttpClientResponseException e) {
-            if (clientSocket == null && (
-                    e.getStatus() == HttpStatus.UNAUTHORIZED || e.getStatus() == HttpStatus.BAD_REQUEST)) {
+            if (clientSocket == null) {
                 throw new AgentException(String.format("%s: %s", e.getStatus().getReason(), e.getMessage()));
             }
             log.error(e.getMessage());

--- a/src/main/java/bio/cirro/agent/AgentCommand.java
+++ b/src/main/java/bio/cirro/agent/AgentCommand.java
@@ -144,8 +144,8 @@ public class AgentCommand implements Runnable {
      * Initialize the connection to the server if it is not already open
      */
     private void watchAndInitConnection() {
+        var clientSocket = agentClientFactory.getClientSocket();
         try {
-            var clientSocket = agentClientFactory.getClientSocket();
             if (clientSocket == null || !clientSocket.isOpen()) {
                 var connectionInfo = ConnectionInfo.builder()
                         .baseUrl(agentConfig.getUrl())
@@ -166,17 +166,19 @@ public class AgentCommand implements Runnable {
                                 .build()
                 );
             }
-        } catch (WebSocketClientException e) {
+        }
+        // Only throw an exception if the first attempt to connect has failed
+        // (clientSocket will be null) Exceptions will cause the agent to exit
+        catch (WebSocketClientException e) {
             var msg = e.getMessage();
-            if (msg.contains(HttpStatus.BAD_REQUEST.getReason())) {
-                throw new AgentException("Bad Request: invalid connection info, check agent ID");
-            }
-            if (msg.contains(HttpStatus.UNAUTHORIZED.getReason())) {
-                throw new AgentException("Unauthorized: check JWT");
+            if (clientSocket == null) {
+                throw new AgentException("Failed to connect, check agent ID: " + msg);
             }
             log.error(e.getMessage());
-        } catch (HttpClientResponseException e) {
-            if (e.getStatus() == HttpStatus.UNAUTHORIZED || e.getStatus() == HttpStatus.BAD_REQUEST) {
+        }
+        catch (HttpClientResponseException e) {
+            if (clientSocket == null && (
+                    e.getStatus() == HttpStatus.UNAUTHORIZED || e.getStatus() == HttpStatus.BAD_REQUEST)) {
                 throw new AgentException(String.format("%s: %s", e.getStatus().getReason(), e.getMessage()));
             }
             log.error(e.getMessage());


### PR DESCRIPTION
We only want to stop the agent if there is an exception on the first connection attempt. On other connection attempts it should try to re-connect in the background.