### PR TITLE
Log error when API returns internal server error

### DIFF
--- a/src/main/java/bio/cirro/agent/exception/ApiExceptionHandler.java
+++ b/src/main/java/bio/cirro/agent/exception/ApiExceptionHandler.java
@@ -29,6 +29,8 @@ public class ApiExceptionHandler implements ExceptionHandler<RuntimeException, H
         };
         if (status == HttpStatus.INTERNAL_SERVER_ERROR) {
             log.error("Unhandled exception", exception);
+        } else {
+            log.info("Error in API request: {}", exception.getMessage());
         }
         return HttpResponse.status(status).body(new ErrorMessage(exception.getMessage()));
     }

--- a/src/main/java/bio/cirro/agent/exception/ApiExceptionHandler.java
+++ b/src/main/java/bio/cirro/agent/exception/ApiExceptionHandler.java
@@ -8,6 +8,7 @@ import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.server.exceptions.ExceptionHandler;
 import io.micronaut.serde.annotation.Serdeable;
 import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Handles exceptions thrown by the API.
@@ -15,16 +16,20 @@ import jakarta.inject.Singleton;
 @Produces
 @Singleton
 @Requires(classes = {ExceptionHandler.class})
+@Slf4j
 public class ApiExceptionHandler implements ExceptionHandler<RuntimeException, HttpResponse<?>> {
 
     @Override
     public HttpResponse<?> handle(HttpRequest request, RuntimeException exception) {
-        var status = switch (exception ) {
+        var status = switch (exception) {
             case SecurityException ignore -> HttpStatus.FORBIDDEN;
             case IllegalArgumentException ignore -> HttpStatus.BAD_REQUEST;
             case IllegalStateException ignore -> HttpStatus.BAD_REQUEST;
             default -> HttpStatus.INTERNAL_SERVER_ERROR;
         };
+        if (status == HttpStatus.INTERNAL_SERVER_ERROR) {
+            log.error("Unhandled exception", exception);
+        }
         return HttpResponse.status(status).body(new ErrorMessage(exception.getMessage()));
     }
 


### PR DESCRIPTION
Agent should have some indication when an API call has an error.

Currently it will just send the error back to the caller and not print anything on the agent log.