### PR TITLE
Catch http client exception

### DIFF
--- a/src/main/java/bio/cirro/agent/AgentCommand.java
+++ b/src/main/java/bio/cirro/agent/AgentCommand.java
@@ -14,6 +14,7 @@ import io.micronaut.context.env.Environment;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.exceptions.HttpClientException;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.logging.LogLevel;
 import io.micronaut.logging.LoggingSystem;
@@ -175,9 +176,13 @@ public class AgentCommand implements Runnable {
             }
             log.error(e.getMessage());
         }
-        catch (HttpClientResponseException e) {
+        catch (HttpClientException e) {
             if (clientSocket == null) {
-                throw new AgentException(String.format("%s: %s", e.getStatus().getReason(), e.getMessage()));
+                var status = "Error";
+                if (e instanceof HttpClientResponseException responseException) {
+                    status = responseException.getStatus().getReason();
+                }
+                throw new AgentException(String.format("%s: %s", status, e.getMessage()));
             }
             log.error(e.getMessage());
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,7 @@ cirro:
     jwt-expiry-days: 7
     submit-script-name: submit_headnode.sh
     stop-script-name: stop_headnode.sh
+micronaut:
+  http:
+    client:
+      read-timeout: 15s


### PR DESCRIPTION
Catch `HttpClientException` instead of just `HttpClientResponseException` to handle other cases.

Also increase http client's read timeout