### PR TITLE
Fix S3 credentials generation check

### DIFF
--- a/src/main/java/bio/cirro/agent/execution/Execution.java
+++ b/src/main/java/bio/cirro/agent/execution/Execution.java
@@ -32,6 +32,7 @@ public class Execution {
     private Status status;
     private ExecutionStartOutput startOutput;
     private ExecutionFinishOutput finishOutput;
+    private Instant finishedAt;
 
     public String getDatasetId() {
         return messageData.getDatasetId();

--- a/src/main/java/bio/cirro/agent/execution/ExecutionService.java
+++ b/src/main/java/bio/cirro/agent/execution/ExecutionService.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -79,7 +80,11 @@ public class ExecutionService {
 
     private void updateStatusInternal(Execution execution, UpdateStatusRequest request) {
         execution.setStatus(request.status());
-        execution.setFinishOutput(new ExecutionFinishOutput(request.message()));
+
+        if (request.status() == Status.COMPLETED || request.status() == Status.FAILED) {
+            execution.setFinishedAt(Instant.now());
+            execution.setFinishOutput(new ExecutionFinishOutput(request.message()));
+        }
 
         var socket = agentClientFactory.getClientSocket();
         if (!socket.isOpen()) {

--- a/src/main/java/bio/cirro/agent/execution/ExecutionTokenService.java
+++ b/src/main/java/bio/cirro/agent/execution/ExecutionTokenService.java
@@ -36,7 +36,7 @@ public class ExecutionTokenService {
         // finishedAt will not be set unless the execution has completed or failed.
         var isAfterThreshold = Optional.ofNullable(execution.getFinishedAt())
                 .map(finished -> finished.plus(Duration.ofMinutes(1)))
-                .map(threshold ->threshold.isAfter(Instant.now()))
+                .map(threshold ->threshold.isBefore(Instant.now()))
                 .orElse(false);
         if (isAfterThreshold) {
             throw new IllegalStateException("Execution already completed");

--- a/src/main/java/bio/cirro/agent/execution/ExecutionTokenService.java
+++ b/src/main/java/bio/cirro/agent/execution/ExecutionTokenService.java
@@ -52,7 +52,7 @@ public class ExecutionTokenService {
         }
 
         log.debug("Generating S3 credentials for execution: {}", executionId);
-        var tokenClient = new AwsTokenClient(stsClient, execution.getFileAccessRoleArn(), agentConfig.getId());
+        var tokenClient = createTokenClient(execution);
         var creds = tokenClient.generateCredentialsForExecution(execution);
         var credsResponse = AwsCredentials.builder()
                 .accessKeyId(creds.accessKeyId())
@@ -62,5 +62,9 @@ public class ExecutionTokenService {
                 .build();
         executionCredentialsCache.put(executionId, credsResponse);
         return credsResponse;
+    }
+
+    protected AwsTokenClient createTokenClient(Execution execution) {
+        return new AwsTokenClient(stsClient, execution.getFileAccessRoleArn(), agentConfig.getId());
     }
 }

--- a/src/test/java/bio/cirro/agent/execution/ExecutionTokenServiceTest.java
+++ b/src/test/java/bio/cirro/agent/execution/ExecutionTokenServiceTest.java
@@ -1,0 +1,59 @@
+package bio.cirro.agent.execution;
+
+import bio.cirro.agent.AgentConfig;
+import bio.cirro.agent.aws.AwsTokenClient;
+import bio.cirro.agent.aws.S3Path;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.services.sts.StsClient;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+public class ExecutionTokenServiceTest {
+    private static final String MOCK_ID = "test";
+    ExecutionTokenService executionTokenService;
+    Execution mockExecution;
+
+    @BeforeEach
+    void setUp() {
+        var executionRepository = mock(ExecutionRepository.class);
+        var stsClient = mock(StsClient.class);
+        var agentConfig = mock(AgentConfig.class);
+        mockExecution = mock(Execution.class);
+        doReturn(MOCK_ID).when(mockExecution).getDatasetId();
+        doReturn(mockExecution).when(executionRepository).get(MOCK_ID);
+        doReturn(S3Path.parse("s3://project/dataset")).when(mockExecution).getDatasetS3Path();
+        executionTokenService = spy(new ExecutionTokenService(executionRepository, stsClient, agentConfig));
+        var tokenClient = mock(AwsTokenClient.class);
+        doReturn(tokenClient).when(executionTokenService).createTokenClient(any());
+        doReturn(mock(AwsSessionCredentials.class)).when(tokenClient).generateCredentialsForExecution(any());
+    }
+
+    @Test
+    void testGenerateS3Credentials_happyPath() {
+        var creds = executionTokenService.generateS3Credentials(MOCK_ID);
+        Assertions.assertNotNull(creds);
+    }
+
+    @Test
+    void testGenerateS3Credentials_withinThreshold() {
+        doReturn(Instant.now().minus(Duration.ofSeconds(10))).when(mockExecution).getFinishedAt();
+        var creds = executionTokenService.generateS3Credentials(MOCK_ID);
+        Assertions.assertNotNull(creds);
+    }
+
+    @Test
+    void testGenerateS3CredentialsCompleted_throwsError() {
+        doReturn(Instant.now().minus(Duration.ofHours(1))).when(mockExecution).getFinishedAt();
+        Assertions.assertThrows(RuntimeException.class,
+                () -> executionTokenService.generateS3Credentials(MOCK_ID));
+    }
+}

--- a/src/test/java/bio/cirro/agent/execution/ExecutionTokenServiceTest.java
+++ b/src/test/java/bio/cirro/agent/execution/ExecutionTokenServiceTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
-public class ExecutionTokenServiceTest {
+class ExecutionTokenServiceTest {
     private static final String MOCK_ID = "test";
     ExecutionTokenService executionTokenService;
     Execution mockExecution;


### PR DESCRIPTION
Allow the execution to request S3 token for a short period after (1 minute) completing to allow the headnode to clean up properly.