### PR TITLE
Add notes on overriding log configuration / fix `run_headnode.sh` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,20 @@ When running behind a reverse proxy, change the endpoint configuration property 
 
 Debug mode can be enabled on the application by specifying the `--debug` flag on launch or setting log level to `DEBUG` in the configuration.
 
+### Logging
+
+The agent logs to the console (stdout) by default.
+
+You can also override the default log configuration by providing a custom Logback configuration file and specifying the `logger.config` property in your configuration.
+
+```
+logger:
+  config: logback-override.xml
+```
+
+A sample Logback configuration file that writes to both the console and a log file is available at [logback-override.xml](./logback-override.xml).
+The log file is configured to write to `agent.log`, rotate daily, and keep 7 days of logs.
+
 ## Development
 
 Run the agent using IntelliJ IDEA or run through the built jar file:

--- a/logback-override.xml
+++ b/logback-override.xml
@@ -1,0 +1,30 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <property name="LOG_FILE" value="agent" />
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_FILE}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- daily rollover -->
+            <fileNamePattern>${LOG_FILE}.%d{yyyy-MM-dd}.gz</fileNamePattern>
+
+            <!-- keep 30 days' worth of history capped at 3GB total size -->
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>10MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE" />
+    </root>
+</configuration>

--- a/script-templates/slurm/run_headnode.sh
+++ b/script-templates/slurm/run_headnode.sh
@@ -48,7 +48,6 @@ mkdir -p "${TMPDIR}/.nextflow"
 
 # Run the headnode image
 apptainer run \
-    --fakeroot \
     --containall \
     --bind "${PW_PROJECT_DIR}" \
     --env-file "${PW_ENVIRONMENT_FILE}" \

--- a/script-templates/slurm/run_headnode.sh
+++ b/script-templates/slurm/run_headnode.sh
@@ -55,6 +55,7 @@ apptainer run \
     --workdir "${TMPDIR}" \
     --env NXF_HOME="${PW_PROJECT_DIR}/.nextflow" \
     --bind "${PW_SHARED_DIR}:${PW_SHARED_DIR}:ro" \
+    --bind "${HOME}/.apptainer" \
     --bind /app/software/Apptainer \
     --bind /etc/slurm \
     --bind /usr/bin/scancel \

--- a/script-templates/slurm/run_headnode.sh
+++ b/script-templates/slurm/run_headnode.sh
@@ -54,6 +54,7 @@ apptainer run \
     --pwd "${PW_WORKING_DIR}" \
     --workdir "${TMPDIR}" \
     --env NXF_HOME="${PW_PROJECT_DIR}/.nextflow" \
+    --env NXF_CACHE_DIR="${PW_PROJECT_DIR}/.nextflow" \
     --bind "${PW_SHARED_DIR}:${PW_SHARED_DIR}:ro" \
     --bind /app/software/Apptainer \
     --bind /etc/slurm \

--- a/script-templates/slurm/run_headnode.sh
+++ b/script-templates/slurm/run_headnode.sh
@@ -54,7 +54,6 @@ apptainer run \
     --pwd "${PW_WORKING_DIR}" \
     --workdir "${TMPDIR}" \
     --env NXF_HOME="${PW_PROJECT_DIR}/.nextflow" \
-    --env NXF_CACHE_DIR="${PW_PROJECT_DIR}/.nextflow" \
     --bind "${PW_SHARED_DIR}:${PW_SHARED_DIR}:ro" \
     --bind /app/software/Apptainer \
     --bind /etc/slurm \


### PR DESCRIPTION
Provide an example of a log configuration that writes to a file and rotates every day.

Remove fakeroot in run example to get rid of squeue error
