### PR TITLE
Ignore execution stop error

### DIFF
--- a/src/main/java/bio/cirro/agent/execution/ExecutionService.java
+++ b/src/main/java/bio/cirro/agent/execution/ExecutionService.java
@@ -62,7 +62,7 @@ public class ExecutionService {
 
             stopProcess.waitFor(10, TimeUnit.SECONDS);
             if (stopProcess.exitValue() != 0) {
-                throw new ExecutionException("Failed to stop execution. Output: " + output);
+                log.error("Failed to stop execution. Output: {}", output);
             }
             stopProcess.destroy();
             var updateRequest = UpdateStatusRequest.builder()


### PR DESCRIPTION
When execution fails to stop, still send back the failed status to Cirro.